### PR TITLE
Updated string for Masternode script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ Castle is a cutting edge cryptocurrency, with many features not available in mos
 <table>
   <th colspan=1>Masternode Installation Script:</th>
   <tr><td>Remote Masternode VPS, Ubuntu 16.04 LTS, 1GB RAM, 1 CPU Core </td></td>  
-<tr><td>wget -O - https://raw.githubusercontent.com/growaleaf/CastleMN/master/CastleMN-Install.sh | sudo bash</td></td>
+<tr><td>sudo curl -L https://raw.githubusercontent.com/growaleaf/CastleMN/master/CastleMN-Install.sh | bash</td></td>
 </table>


### PR DESCRIPTION
Previous string produced an extra carriage return, which did not allow operators to enter private Masternode key